### PR TITLE
Fix header send issue

### DIFF
--- a/index.php
+++ b/index.php
@@ -6,8 +6,6 @@
 	$session = Session::getInstance();
 	$file = new FileHandler;
 
-	require 'views/header.php';
-
 	if(!$session->is_logged_in())
 	{
 		header("Location: login.php");
@@ -50,6 +48,8 @@
 			}
 		}
 	}
+
+	require 'views/header.php';
 ?>
 		<div class="container">
 			<h1>Download</h1>


### PR DESCRIPTION
With 'security' enabled it did only show an almost empty page without any possibility to enter a password anywhere.
Apache logged following php warning:
` PHP Warning:  Cannot modify header information - headers already sent by (output started at /var/www/html/yt/views/header.php:1) in /var/www/html/yt/index.php on line 13`
I then cross-checked with logs.php because there the login dialog occured and placed the require statement at the end as well. Now the login works.

Sorry I'm completely unfamiliar with php, so maybe my solution is garbage.