### PR TITLE
Modify $cmd to use PO Tokens if the $url is from youtube.com

### DIFF
--- a/class/Downloader.php
+++ b/class/Downloader.php
@@ -269,7 +269,7 @@ class Downloader
 		
 	}
 
-	private function do_download($audio_only)
+/* 	private function do_download($audio_only)
 	{
 		$cmd = $this->config["bin"];
 		$cmd .= " --ignore-error -o ".$this->download_path."/";
@@ -302,6 +302,54 @@ class Downloader
 		$cmd .= " & echo $!";
 
 		shell_exec($cmd);
+	} */
+
+	// Modify the command to use POT
+	private function do_download($audio_only)
+	{
+		$cmd = $this->config["bin"];
+		$cmd .= " --ignore-error -o ".$this->download_path."/";
+		$cmd .= escapeshellarg($this->outfilename);
+	
+		if ($this->vformat) 
+		{
+			$cmd .= " --format ";
+			$cmd .= escapeshellarg($this->vformat);
+		}
+		if($audio_only)
+		{
+			$cmd .= " -x ";
+		}
+		$cmd .= " --restrict-filenames"; // --restrict-filenames is for specials chars
+	
+		 // Prepare generate_once.js path in the same directory as bin
+        $binPath = $this->config["bin"];
+        $binDir = dirname($binPath);
+        $generateOnceJSPath = $binDir . '/bgutil-ytdlp-pot-provider/server/build/generate_once.js';
+	
+		foreach($this->urls as $url)
+		{
+			$cmdForUrl = $cmd;
+			if (strpos($url, 'youtube.com') !== false || strpos($url, 'youtu.be') !== false) {
+				$cmdForUrl .= ' --extractor-args ';
+				$cmdForUrl .= '"youtube:getpot_bgutil_script=' . $generateOnceJSPath . '"';
+			}
+			$cmdForUrl .= " ".escapeshellarg($url);
+	
+			if($this->config["log"])
+			{
+				$cmdForUrl = "{ echo Command: ".escapeshellarg($cmdForUrl)."; ".$cmdForUrl." ; }";
+				$cmdForUrl .= " > ".$this->log_path."/$(date  +\"%Y-%m-%d_%H-%M-%S-%N\").txt";
+			}
+			else
+			{
+				$cmdForUrl .= " > /dev/null ";
+			}
+	
+			$cmdForUrl .= " & echo $!";
+	
+			shell_exec($cmdForUrl);
+		}
 	}
 
 	private function do_info()


### PR DESCRIPTION
YouTube is starting to enforce the requirement of PO Tokens.

I did a quick and dirty hack to add `--extractor-args` to use PO Tokens per the official [PO Token Guide](https://github.com/yt-dlp/yt-dlp/wiki/PO-Token-Guide)

I didn't document exactly what's needed because I was in a rush, but I've tested and it works perfectly every time. Basically involves adding two plugins to the `yt-dlp` plugins directory and also building the `generate_once.js` per [bgutil-ytdlp-pot-provider](https://github.com/Brainicism/bgutil-ytdlp-pot-provider) (see the above linked guide for exactly what's needed). 

I wanted to provide this just as a starting point for you to probably do a better job than I did, so feel free to deny this PR and do your own implementation. Or, I don't mind, when I have time, building out better documentation and even making this work a little cleaner. It probably needs to be further modified to check for the existence of the two plugins and the `generate_once.js` file as well, when the $url is from youtube.com/youtu.be.